### PR TITLE
Fix for first day of the month

### DIFF
--- a/api/handlers_spaces.go
+++ b/api/handlers_spaces.go
@@ -33,6 +33,11 @@ func (s *server) SpaceGetHandler(w http.ResponseWriter, r *http.Request) {
 	log.Debugf("getting costs for space %s", spaceID)
 
 	y, m, d := time.Now().Date()
+
+	// if it's the first day of the month, get todays usage thus far
+	if d == 1 {
+		d = 2
+	}
 	input := costexplorer.GetCostAndUsageInput{
 		Filter: &costexplorer.Expression{
 			And: []*costexplorer.Expression{
@@ -55,12 +60,6 @@ func (s *server) SpaceGetHandler(w http.ResponseWriter, r *http.Request) {
 			},
 		},
 		Granularity: aws.String("MONTHLY"),
-		GroupBy: []*costexplorer.GroupDefinition{
-			&costexplorer.GroupDefinition{
-				Key:  aws.String("SERVICE"),
-				Type: aws.String("DIMENSION"),
-			},
-		},
 		Metrics: []*string{
 			aws.String("BLENDED_COST"),
 			aws.String("USAGE_QUANTITY"),

--- a/api/handlers_spaces.go
+++ b/api/handlers_spaces.go
@@ -50,10 +50,22 @@ func (s *server) SpaceGetHandler(w http.ResponseWriter, r *http.Request) {
 					},
 				},
 				&costexplorer.Expression{
-					Tags: &costexplorer.TagValues{
-						Key: aws.String("yale:org"),
-						Values: []*string{
-							aws.String(Org),
+					Or: []*costexplorer.Expression{
+						&costexplorer.Expression{
+							Tags: &costexplorer.TagValues{
+								Key: aws.String("yale:org"),
+								Values: []*string{
+									aws.String(Org),
+								},
+							},
+						},
+						&costexplorer.Expression{
+							Tags: &costexplorer.TagValues{
+								Key: aws.String("spinup:org"),
+								Values: []*string{
+									aws.String(Org),
+								},
+							},
 						},
 					},
 				},
@@ -62,6 +74,7 @@ func (s *server) SpaceGetHandler(w http.ResponseWriter, r *http.Request) {
 		Granularity: aws.String("MONTHLY"),
 		Metrics: []*string{
 			aws.String("BLENDED_COST"),
+			aws.String("UNBLENDED_COST"),
 			aws.String("USAGE_QUANTITY"),
 		},
 		TimePeriod: &costexplorer.DateInterval{


### PR DESCRIPTION
The first day of the month will throw an error since the `Start` and `End` are the same.  This resolves that issue.  

It also fixes a few minor things:
* removes the grouping by SERVICE, which we agreed is unnecessary
* adds an `OR` to filter by `yale:org` or `spinup:org` since we have both
* adds back unblended cost to make it easier to compare if we find any inconsistencies