### PR TITLE
Support getting container service metrics, move metrics to a metrics endpoint, consolidate query processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ GET /v1/cost/{account}/spaces/{spaceid}[?start=2019-10-01&end=2019-10-30]
 
 GET /v1/cost/{account}/instances/{id}/metrics/graph.png?metric={metric1}[&metric={metric2}&start=-P1D&end=PT0H&period=300]
 GET /v1/cost/{account}/instances/{id}/metrics/graph?metric={metric1}[&metric={metric2}&start=-P1D&end=PT0H&period=300]
+
+GET /v1/metrics/{account}/instances/{id}/graph.png?metric={metric1}[&metric={metric2}&start=-P1D&end=PT0H&period=300]
+GET /v1/metrics/{account}/instances/{id}/graph?metric={metric1}[&metric={metric2}&start=-P1D&end=PT0H&period=300]
+GET /v1/metrics/{account}/clusters/{cluster}/services/{service}/graph.png?metric={metric1}[&metric={metric2}&start=-P1D&end=PT0H&period=300]
+GET /v1/metrics/{account}/clusters/{cluster}/services/{service}/graph?metric={metric1}[&metric={metric2}&start=-P1D&end=PT0H&period=300]
 ```
 
 ## Usage
@@ -58,15 +63,18 @@ GET /v1/cost/{account}/spaces/{spaceid}
 
 ### Get cloudwatch metrics widgets for an instance ID
 
-This will get the passed metric(s) for the passed instance ID in a `image/png` graph for the past 1 day by default. It's also
+This will get the passed metric(s) for the passed instance ID or container cluster/service in a `image/png` graph for the past 1 day by default. It's also
 possible to pass the start time, end time and period (e. `300s` for 300 seconds, `5m` for 5 minutes).  Query parameters must follow
 the [CloudWatch Metric Widget Structure](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/CloudWatch-Metric-Widget-Structure.html).
 
 #### Request
 
 ```
-GET /v1/cost/{account}/instances/{id}/metrics/graph.png?metric={metric1}[&metric={metric2}&....]
-GET /v1/cost/{account}/instances/{id}/metrics/graph.png?metric={metric1}[&metric={metric2}&start={start}&end={end}&period={period}]
+GET /v1/metrics/{account}/instances/{id}/graph.png?metric={metric1}[&metric={metric2}&....]
+GET /v1/metrics/{account}/instances/{id}/graph.png?metric={metric1}[&metric={metric2}&start={start}&end={end}&period={period}]
+
+GET /v1/metrics/{account}/clusters/{cluster}/services/{service}/graph.png?metric={metric1}[&metric={metric2}&....]
+GET /v1/metrics/{account}/clusters/{cluster}/services/{service}/graph.png?metric={metric1}[&metric={metric2}&start={start}&end={end}&period={period}]
 ```
 
 #### Response
@@ -75,15 +83,19 @@ GET /v1/cost/{account}/instances/{id}/metrics/graph.png?metric={metric1}[&metric
 
 ### Get cloudwatch metrics widgets URL from S3 for an instance ID
 
-This will get the passed metric(s) for the passed instance ID in a `image/png` graph for the past 1 day by default, cache it in S3
+This will get the passed metric(s) for the passed instance ID or container cluster/service in a `image/png` graph for the past 1 day by default, cache it in S3
 and return the URL. URLs are cached in the API for 5 minutes, the images should be purged from the S3 cache on a schedule. It's also
-possible to pass the start time, end time and period (e. `300s` for 300 seconds, `5m` for 5 minutes).  Query parameters must follow the [CloudWatch Metric Widget Structure](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/CloudWatch-Metric-Widget-Structure.html).
+possible to pass the start time, end time and period (e. `300s` for 300 seconds, `5m` for 5 minutes).  Query parameters must follow
+the [CloudWatch Metric Widget Structure](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/CloudWatch-Metric-Widget-Structure.html).
 
 #### Request
 
 ```
-GET /v1/cost/{account}/instances/{id}/metrics/graph?metric={metric1}[&metric={metric2}&....]
-GET /v1/cost/{account}/instances/{id}/metrics/graph?metric={metric1}[&metric={metric2}&start={start}&end={end}&period={period}]
+GET /v1/metrics/{account}/instances/{id}/graph?metric={metric1}[&metric={metric2}&....]
+GET /v1/metrics/{account}/instances/{id}/graph?metric={metric1}[&metric={metric2}&start={start}&end={end}&period={period}]
+
+GET /v1/metrics/{account}/clusters/{cluster}/services/{service}/graph?metric={metric1}[&metric={metric2}&....]
+GET /v1/metrics/{account}/clusters/{cluster}/services/{service}/graph?metric={metric1}[&metric={metric2}&start={start}&end={end}&period={period}]
 ```
 
 #### Response

--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ GET /v1/cost/{account}/spaces/{spaceid}[?start=2019-10-01&end=2019-10-30]
 GET /v1/cost/{account}/instances/{id}/metrics/graph.png?metric={metric1}[&metric={metric2}&start=-P1D&end=PT0H&period=300]
 GET /v1/cost/{account}/instances/{id}/metrics/graph?metric={metric1}[&metric={metric2}&start=-P1D&end=PT0H&period=300]
 
-GET /v1/metrics/{account}/instances/{id}/graph.png?metric={metric1}[&metric={metric2}&start=-P1D&end=PT0H&period=300]
 GET /v1/metrics/{account}/instances/{id}/graph?metric={metric1}[&metric={metric2}&start=-P1D&end=PT0H&period=300]
-GET /v1/metrics/{account}/clusters/{cluster}/services/{service}/graph.png?metric={metric1}[&metric={metric2}&start=-P1D&end=PT0H&period=300]
 GET /v1/metrics/{account}/clusters/{cluster}/services/{service}/graph?metric={metric1}[&metric={metric2}&start=-P1D&end=PT0H&period=300]
 ```
 
@@ -61,26 +59,6 @@ GET /v1/cost/{account}/spaces/{spaceid}
 ]
 ```
 
-### Get cloudwatch metrics widgets for an instance ID
-
-This will get the passed metric(s) for the passed instance ID or container cluster/service in a `image/png` graph for the past 1 day by default. It's also
-possible to pass the start time, end time and period (e. `300s` for 300 seconds, `5m` for 5 minutes).  Query parameters must follow
-the [CloudWatch Metric Widget Structure](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/CloudWatch-Metric-Widget-Structure.html).
-
-#### Request
-
-```
-GET /v1/metrics/{account}/instances/{id}/graph.png?metric={metric1}[&metric={metric2}&....]
-GET /v1/metrics/{account}/instances/{id}/graph.png?metric={metric1}[&metric={metric2}&start={start}&end={end}&period={period}]
-
-GET /v1/metrics/{account}/clusters/{cluster}/services/{service}/graph.png?metric={metric1}[&metric={metric2}&....]
-GET /v1/metrics/{account}/clusters/{cluster}/services/{service}/graph.png?metric={metric1}[&metric={metric2}&start={start}&end={end}&period={period}]
-```
-
-#### Response
-
-![WidgetExample](/img/example_response.png?raw=true)
-
 ### Get cloudwatch metrics widgets URL from S3 for an instance ID
 
 This will get the passed metric(s) for the passed instance ID or container cluster/service in a `image/png` graph for the past 1 day by default, cache it in S3
@@ -105,6 +83,10 @@ GET /v1/metrics/{account}/clusters/{cluster}/services/{service}/graph?metric={me
     "ImageURL": "https://s3.amazonaws.com/sometestbucket/aabbccddeeff-Y3_yCKckBrkUNt3Lh4LzXBFeLXBY5IP1oUED4hyY0cdKneYelKv-xlV7K2F_d0ccwp677A=="
 }
 ```
+
+with an image like this
+
+![WidgetExample](/img/example_response.png?raw=true)
 
 ## Image Caching
 

--- a/api/handlers_metrics.go
+++ b/api/handlers_metrics.go
@@ -48,7 +48,7 @@ func (s *server) GetEC2MetricsImageHandler(w http.ResponseWriter, r *http.Reques
 	req["metrics"] = cwMetrics
 
 	log.Debugf("getting metrics  with request %+v", req)
-	out, err := cwService.GetInstanceMetricWidget(r.Context(), req)
+	out, err := cwService.GetMetricWidget(r.Context(), req)
 	if err != nil {
 		log.Errorf("failed getting metrics widget image: %s", err)
 		handleError(w, err)
@@ -118,7 +118,7 @@ func (s *server) GetEC2MetricsURLHandler(w http.ResponseWriter, r *http.Request)
 	req["metrics"] = cwMetrics
 
 	log.Debugf("getting metrics with request %+v", req)
-	image, err := cwService.GetInstanceMetricWidget(r.Context(), req)
+	image, err := cwService.GetMetricWidget(r.Context(), req)
 	if err != nil {
 		log.Errorf("failed getting metrics widget image: %s", err)
 		handleError(w, err)
@@ -174,7 +174,7 @@ func (s *server) GetECSMetricsImageHandler(w http.ResponseWriter, r *http.Reques
 	req["metrics"] = cwMetrics
 
 	log.Debugf("getting metrics with request %+v", req)
-	out, err := cwService.GetInstanceMetricWidget(r.Context(), req)
+	out, err := cwService.GetMetricWidget(r.Context(), req)
 	if err != nil {
 		log.Errorf("failed getting metrics widget image: %s", err)
 		handleError(w, err)
@@ -246,7 +246,7 @@ func (s *server) GetECSMetricsURLHandler(w http.ResponseWriter, r *http.Request)
 	req["metrics"] = cwMetrics
 
 	log.Debugf("getting metrics with request %+v", req)
-	image, err := cwService.GetInstanceMetricWidget(r.Context(), req)
+	image, err := cwService.GetMetricWidget(r.Context(), req)
 	if err != nil {
 		log.Errorf("failed getting metrics widget image: %s", err)
 		handleError(w, err)

--- a/api/handlers_metrics.go
+++ b/api/handlers_metrics.go
@@ -3,51 +3,22 @@ package api
 import (
 	"fmt"
 	"net/http"
-	"sort"
 	"strings"
 	"time"
 
 	"github.com/YaleSpinup/cost-api/apierror"
 	"github.com/YaleSpinup/cost-api/cloudwatch"
 	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
-// MetricsGetImageHandler gets metrics from cloudwatch
-func (s *server) MetricsGetImageHandler(w http.ResponseWriter, r *http.Request) {
+// GetEC2MetricsImageHandler gets metrics from cloudwatch
+func (s *server) GetEC2MetricsImageHandler(w http.ResponseWriter, r *http.Request) {
 	w = LogWriter{w}
 	vars := mux.Vars(r)
 	account := vars["account"]
-	id := vars["id"]
-
-	queries := r.URL.Query()
-	metrics := queries["metric"]
-	if len(metrics) == 0 {
-		handleError(w, apierror.New(apierror.ErrBadRequest, "at least one metric is required", nil))
-		return
-	}
-
-	period := int64(300)
-	if p, ok := vars["period"]; ok && p != "" {
-		dur, err := time.ParseDuration(p)
-		if err != nil {
-			msg := fmt.Sprintf("failed to parse period as duration: %s", err)
-			handleError(w, apierror.New(apierror.ErrNotFound, msg, nil))
-			return
-		}
-
-		period = int64(dur.Seconds())
-	}
-
-	start := "-P1D"
-	if s, ok := vars["start"]; ok {
-		start = s
-	}
-
-	end := "PT0H"
-	if e, ok := vars["end"]; ok {
-		end = e
-	}
+	instanceId := vars["id"]
 
 	cwService, ok := s.cloudwatchServices[account]
 	if !ok {
@@ -57,13 +28,27 @@ func (s *server) MetricsGetImageHandler(w http.ResponseWriter, r *http.Request) 
 	}
 	log.Debugf("found cloudwatch service %+v", cwService)
 
-	cwMetrics := []cloudwatch.Metric{}
-	for _, m := range metrics {
-		cwMetrics = append(cwMetrics, cloudwatch.Metric{"AWS/EC2", m, "InstanceId", id})
+	queries := r.URL.Query()
+	metrics := queries["metric"]
+	if len(metrics) == 0 {
+		handleError(w, apierror.New(apierror.ErrBadRequest, "at least one metric is required", nil))
+		return
 	}
 
-	log.Debugf("getting metrics %+v, start: %s, end: %s with period: %ds", cwMetrics, start, end, period)
-	out, err := cwService.GetMetricWidget(r.Context(), cwMetrics, period, start, end)
+	req := cloudwatch.MetricsRequest{}
+	if err := parseQuery(r, req); err != nil {
+		handleError(w, apierror.New(apierror.ErrBadRequest, "failed to parse query", err))
+		return
+	}
+
+	cwMetrics := []cloudwatch.Metric{}
+	for _, m := range metrics {
+		cwMetrics = append(cwMetrics, cloudwatch.Metric{"AWS/EC2", m, "InstanceId", instanceId})
+	}
+	req["metrics"] = cwMetrics
+
+	log.Debugf("getting metrics  with request %+v", req)
+	out, err := cwService.GetInstanceMetricWidget(r.Context(), req)
 	if err != nil {
 		log.Errorf("failed getting metrics widget image: %s", err)
 		handleError(w, err)
@@ -75,42 +60,12 @@ func (s *server) MetricsGetImageHandler(w http.ResponseWriter, r *http.Request) 
 	w.Write(out)
 }
 
-// MetricsGetURLHandler gets metrics from cloudwatch and returns a link to the image
-func (s *server) MetricsGetImageUrlHandler(w http.ResponseWriter, r *http.Request) {
+// GetEC2MetricsURLHandler gets metrics from cloudwatch and returns a link to the image
+func (s *server) GetEC2MetricsURLHandler(w http.ResponseWriter, r *http.Request) {
 	w = LogWriter{w}
 	vars := mux.Vars(r)
 	account := vars["account"]
-	id := vars["id"]
-
-	queries := r.URL.Query()
-	metrics := queries["metric"]
-	if len(metrics) == 0 {
-		handleError(w, apierror.New(apierror.ErrBadRequest, "at least one metric is required", nil))
-		return
-	}
-	sort.Strings(metrics)
-
-	period := int64(300)
-	if p, ok := vars["period"]; ok && p != "" {
-		dur, err := time.ParseDuration(p)
-		if err != nil {
-			msg := fmt.Sprintf("failed to parse period as duration: %s", err)
-			handleError(w, apierror.New(apierror.ErrNotFound, msg, nil))
-			return
-		}
-
-		period = int64(dur.Seconds())
-	}
-
-	start := "-P1D"
-	if s, ok := vars["start"]; ok && s != "" {
-		start = s
-	}
-
-	end := "PT0H"
-	if e, ok := vars["end"]; ok && e != "" {
-		end = e
-	}
+	instanceId := vars["id"]
 
 	cwService, ok := s.cloudwatchServices[account]
 	if !ok {
@@ -128,7 +83,20 @@ func (s *server) MetricsGetImageUrlHandler(w http.ResponseWriter, r *http.Reques
 	}
 	log.Debugf("found cost explorer result cache %+v", *resultCache)
 
-	key := fmt.Sprintf("%s/%s/%s/%s/%s/%d", Org, id, strings.Join(metrics, "-"), start, end, period)
+	queries := r.URL.Query()
+	metrics := queries["metric"]
+	if len(metrics) == 0 {
+		handleError(w, apierror.New(apierror.ErrBadRequest, "at least one metric is required", nil))
+		return
+	}
+
+	req := cloudwatch.MetricsRequest{}
+	if err := parseQuery(r, req); err != nil {
+		handleError(w, apierror.New(apierror.ErrBadRequest, "failed to parse query", err))
+		return
+	}
+
+	key := fmt.Sprintf("%s/%s/%s/%v/%v/%v", Org, instanceId, strings.Join(metrics, "-"), req["start"], req["end"], req["period"])
 	hashedCacheKey := s.imageCache.HashedKey(key)
 	if res, expire, ok := resultCache.GetWithExpiration(hashedCacheKey); ok {
 		log.Debugf("found cached object: %s", res)
@@ -145,11 +113,12 @@ func (s *server) MetricsGetImageUrlHandler(w http.ResponseWriter, r *http.Reques
 
 	cwMetrics := []cloudwatch.Metric{}
 	for _, m := range metrics {
-		cwMetrics = append(cwMetrics, cloudwatch.Metric{"AWS/EC2", m, "InstanceId", id})
+		cwMetrics = append(cwMetrics, cloudwatch.Metric{"AWS/EC2", m, "InstanceId", instanceId})
 	}
+	req["metrics"] = cwMetrics
 
-	log.Debugf("getting metrics %+v, start: %s, end: %s with period: %ds", cwMetrics, start, end, period)
-	image, err := cwService.GetMetricWidget(r.Context(), cwMetrics, period, start, end)
+	log.Debugf("getting metrics with request %+v", req)
+	image, err := cwService.GetInstanceMetricWidget(r.Context(), req)
 	if err != nil {
 		log.Errorf("failed getting metrics widget image: %s", err)
 		handleError(w, err)
@@ -167,4 +136,170 @@ func (s *server) MetricsGetImageUrlHandler(w http.ResponseWriter, r *http.Reques
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	w.Write(meta)
+}
+
+// GetECSMetricsImageHandler gets metrics from cloudwatch
+func (s *server) GetECSMetricsImageHandler(w http.ResponseWriter, r *http.Request) {
+	w = LogWriter{w}
+	vars := mux.Vars(r)
+	account := vars["account"]
+	cluster := vars["cluster"]
+	service := vars["service"]
+
+	cwService, ok := s.cloudwatchServices[account]
+	if !ok {
+		msg := fmt.Sprintf("cloudwatch service not found for account: %s", account)
+		handleError(w, apierror.New(apierror.ErrNotFound, msg, nil))
+		return
+	}
+	log.Debugf("found cloudwatch service %+v", cwService)
+
+	queries := r.URL.Query()
+	metrics := queries["metric"]
+	if len(metrics) == 0 {
+		handleError(w, apierror.New(apierror.ErrBadRequest, "at least one metric is required", nil))
+		return
+	}
+
+	req := cloudwatch.MetricsRequest{}
+	if err := parseQuery(r, req); err != nil {
+		handleError(w, apierror.New(apierror.ErrBadRequest, "failed to parse query", err))
+		return
+	}
+
+	cwMetrics := []cloudwatch.Metric{}
+	for _, m := range metrics {
+		cwMetrics = append(cwMetrics, cloudwatch.Metric{"AWS/ECS", m, "ClusterName", cluster, "ServiceName", service})
+	}
+	req["metrics"] = cwMetrics
+
+	log.Debugf("getting metrics with request %+v", req)
+	out, err := cwService.GetInstanceMetricWidget(r.Context(), req)
+	if err != nil {
+		log.Errorf("failed getting metrics widget image: %s", err)
+		handleError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "image/png")
+	w.WriteHeader(http.StatusOK)
+	w.Write(out)
+}
+
+// GetECSMetricsURLHandler gets metrics from cloudwatch and returns a link to the image
+func (s *server) GetECSMetricsURLHandler(w http.ResponseWriter, r *http.Request) {
+	w = LogWriter{w}
+	vars := mux.Vars(r)
+	account := vars["account"]
+	cluster := vars["cluster"]
+	service := vars["service"]
+
+	cwService, ok := s.cloudwatchServices[account]
+	if !ok {
+		msg := fmt.Sprintf("cloudwatch service not found for account: %s", account)
+		handleError(w, apierror.New(apierror.ErrNotFound, msg, nil))
+		return
+	}
+	log.Debugf("found cloudwatch service %+v", cwService)
+
+	resultCache, ok := s.resultCache[account]
+	if !ok {
+		msg := fmt.Sprintf("result cache not found for account: %s", account)
+		handleError(w, apierror.New(apierror.ErrNotFound, msg, nil))
+		return
+	}
+	log.Debugf("found cost explorer result cache %+v", *resultCache)
+
+	queries := r.URL.Query()
+	metrics := queries["metric"]
+	if len(metrics) == 0 {
+		handleError(w, apierror.New(apierror.ErrBadRequest, "at least one metric is required", nil))
+		return
+	}
+
+	req := cloudwatch.MetricsRequest{}
+	if err := parseQuery(r, req); err != nil {
+		handleError(w, apierror.New(apierror.ErrBadRequest, "failed to parse query", err))
+		return
+	}
+
+	key := fmt.Sprintf("%s/%s/%s/%v/%v/%v", Org, fmt.Sprintf("%s-%s", cluster, service), strings.Join(metrics, "-"), req["start"], req["end"], req["period"])
+	hashedCacheKey := s.imageCache.HashedKey(key)
+	if res, expire, ok := resultCache.GetWithExpiration(hashedCacheKey); ok {
+		log.Debugf("found cached object: %s", res)
+
+		if body, ok := res.([]byte); ok {
+			w.Header().Set("X-Cache-Hit", "true")
+			w.Header().Set("X-Cache-Expire", fmt.Sprintf("%0.fs", time.Until(expire).Seconds()))
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write(body)
+			return
+		}
+	}
+
+	cwMetrics := []cloudwatch.Metric{}
+	for _, m := range metrics {
+		cwMetrics = append(cwMetrics, cloudwatch.Metric{"AWS/ECS", m, "ClusterName", cluster, "ServiceName", service})
+	}
+	// req.Metrics = cwMetrics
+	req["metrics"] = cwMetrics
+
+	log.Debugf("getting metrics with request %+v", req)
+	image, err := cwService.GetInstanceMetricWidget(r.Context(), req)
+	if err != nil {
+		log.Errorf("failed getting metrics widget image: %s", err)
+		handleError(w, err)
+		return
+	}
+
+	meta, err := s.imageCache.Save(r.Context(), hashedCacheKey, image)
+	if err != nil {
+		log.Errorf("failed saving metrics widget image to cache: %s", err)
+		handleError(w, err)
+		return
+	}
+	resultCache.Set(hashedCacheKey, meta, 300*time.Second)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(meta)
+}
+
+func parseQuery(r *http.Request, request cloudwatch.MetricsRequest) error {
+	log.SetLevel(log.DebugLevel)
+	queries := r.URL.Query()
+	log.Debugf("parsing queries: %+v", queries)
+
+	stat := "Average"
+	if s, ok := queries["stat"]; ok {
+		stat = s[0]
+	}
+	request["stat"] = stat
+
+	period := int64(300)
+	if p, ok := queries["period"]; ok && p[0] != "" {
+		dur, err := time.ParseDuration(p[0])
+		if err != nil {
+			return errors.Wrap(err, "failed to parse period as duration")
+		}
+
+		period = int64(dur.Seconds())
+	}
+	request["period"] = period
+
+	start := "-P1D"
+	if s, ok := queries["start"]; ok {
+		start = s[0]
+	}
+	request["start"] = start
+
+	end := "PT0H"
+	if e, ok := queries["end"]; ok {
+		end = e[0]
+	}
+
+	request["end"] = end
+
+	return nil
 }

--- a/api/handlers_metrics_test.go
+++ b/api/handlers_metrics_test.go
@@ -1,0 +1,112 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/YaleSpinup/cost-api/cloudwatch"
+)
+
+func TestParseQuery(t *testing.T) {
+	type queryParseTest struct {
+		query string
+		input cloudwatch.MetricsRequest
+		err   error
+	}
+
+	tests := []queryParseTest{
+		// happy path
+		{
+			query: "",
+			input: cloudwatch.MetricsRequest{
+				"start":  "-P1D",
+				"end":    "PT0H",
+				"period": int64(300),
+				"stat":   "Average",
+			},
+			err: nil,
+		},
+		{
+			query: "start=-PT1H&end=PT0H&period=10s&stat=Maximum",
+			input: cloudwatch.MetricsRequest{
+				"start":  "-PT1H",
+				"end":    "PT0H",
+				"period": int64(10),
+				"stat":   "Maximum",
+			},
+			err: nil,
+		},
+		{
+			query: "start=-PT1H",
+			input: cloudwatch.MetricsRequest{
+				"start":  "-PT1H",
+				"end":    "PT0H",
+				"period": int64(300),
+				"stat":   "Average",
+			},
+			err: nil,
+		},
+		{
+			query: "end=-PT1H",
+			input: cloudwatch.MetricsRequest{
+				"start":  "-P1D",
+				"end":    "-PT1H",
+				"period": int64(300),
+				"stat":   "Average",
+			},
+			err: nil,
+		},
+		{
+			query: "period=10s",
+			input: cloudwatch.MetricsRequest{
+				"start":  "-P1D",
+				"end":    "PT0H",
+				"period": int64(10),
+				"stat":   "Average",
+			},
+			err: nil,
+		},
+		{
+			query: "stat=Minimum",
+			input: cloudwatch.MetricsRequest{
+				"start":  "-P1D",
+				"end":    "PT0H",
+				"period": int64(300),
+				"stat":   "Minimum",
+			},
+			err: nil,
+		},
+		// errors
+		{
+			query: "period=true",
+			input: cloudwatch.MetricsRequest{},
+			err:   errors.New("failed to parse period as duration: time: invalid duration true"),
+		},
+	}
+
+	for _, test := range tests {
+		input := cloudwatch.MetricsRequest{}
+		r := &http.Request{
+			URL: &url.URL{
+				RawQuery: test.query,
+			},
+		}
+
+		t.Logf("testing raw query %s", test.query)
+
+		if err := parseQuery(r, input); err != nil {
+			if test.err == nil {
+				t.Errorf("expected nil error, got %s", err)
+			} else if test.err.Error() != err.Error() {
+				t.Errorf("expected error %s, got %s", test.err, err)
+			}
+		} else {
+			if !reflect.DeepEqual(input, test.input) {
+				t.Errorf("expected %+v, got %+v", test.input, input)
+			}
+		}
+	}
+}

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -48,3 +48,11 @@ func TokenMiddleware(psk string, public map[string]string, h http.Handler) http.
 		h.ServeHTTP(w, r)
 	})
 }
+
+func ParamMiddleware(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Debug("processing params middleware")
+		log.Infof("done processing params middleware for URL '%s'", r.URL)
+		h.ServeHTTP(w, r)
+	})
+}

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -48,11 +48,3 @@ func TokenMiddleware(psk string, public map[string]string, h http.Handler) http.
 		h.ServeHTTP(w, r)
 	})
 }
-
-func ParamMiddleware(h http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		log.Debug("processing params middleware")
-		log.Infof("done processing params middleware for URL '%s'", r.URL)
-		h.ServeHTTP(w, r)
-	})
-}

--- a/api/routes.go
+++ b/api/routes.go
@@ -7,20 +7,34 @@ import (
 )
 
 func (s *server) routes() {
+
+	// costs subrouter - /v1/cost
 	api := s.router.PathPrefix("/v1/cost").Subrouter()
 	api.HandleFunc("/ping", s.PingHandler).Methods(http.MethodGet)
 	api.HandleFunc("/version", s.VersionHandler).Methods(http.MethodGet)
 	api.Handle("/metrics", promhttp.Handler()).Methods(http.MethodGet)
 
+	// cost endpoints for a space
 	api.HandleFunc("/{account}/spaces/{space}", s.SpaceGetHandler).
 		Queries("start", "{start}", "end", "{end}").Methods(http.MethodGet)
 	api.HandleFunc("/{account}/spaces/{space}", s.SpaceGetHandler).Methods(http.MethodGet)
 
-	api.HandleFunc("/{account}/instances/{id}/metrics/graph.png", s.MetricsGetImageHandler).
-		Queries("period", "{period}", "start", "{start}", "end", "{end}").Methods(http.MethodGet)
-	api.HandleFunc("/{account}/instances/{id}/metrics/graph.png", s.MetricsGetImageHandler).Methods(http.MethodGet)
-	api.HandleFunc("/{account}/instances/{id}/metrics/graph", s.MetricsGetImageUrlHandler).
-		Queries("period", "{period}", "start", "{start}", "end", "{end}").Methods(http.MethodGet)
-	api.HandleFunc("/{account}/instances/{id}/metrics/graph", s.MetricsGetImageUrlHandler).Methods(http.MethodGet)
+	// metrics endpoints for EC2 instances
+	// TODO: deprecated but left for backwards compatability, remove me once the UI is updated
+	api.HandleFunc("/{account}/instances/{id}/metrics/graph.png", s.GetEC2MetricsImageHandler).Methods(http.MethodGet)
+	api.HandleFunc("/{account}/instances/{id}/metrics/graph", s.GetEC2MetricsURLHandler).Methods(http.MethodGet)
 
+	// metrics subrouter - /v1/metrics
+	metricsApi := s.router.PathPrefix("/v1/metrics").Subrouter()
+	metricsApi.HandleFunc("/ping", s.PingHandler).Methods(http.MethodGet)
+	metricsApi.HandleFunc("/version", s.VersionHandler).Methods(http.MethodGet)
+	metricsApi.Handle("/metrics", promhttp.Handler()).Methods(http.MethodGet)
+
+	// metrics endpoints for EC2 instances
+	metricsApi.HandleFunc("/{account}/instances/{id}/graph.png", s.GetEC2MetricsImageHandler).Methods(http.MethodGet)
+	metricsApi.HandleFunc("/{account}/instances/{id}/graph", s.GetEC2MetricsURLHandler).Methods(http.MethodGet)
+
+	// metrics endpoints for ECS services
+	metricsApi.HandleFunc("/{account}/clusters/{cluster}/services/{service}/graph.png", s.GetECSMetricsImageHandler).Methods(http.MethodGet)
+	metricsApi.HandleFunc("/{account}/clusters/{cluster}/services/{service}/graph", s.GetECSMetricsURLHandler).Methods(http.MethodGet)
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -21,7 +21,6 @@ func (s *server) routes() {
 
 	// metrics endpoints for EC2 instances
 	// TODO: deprecated but left for backwards compatability, remove me once the UI is updated
-	api.HandleFunc("/{account}/instances/{id}/metrics/graph.png", s.GetEC2MetricsImageHandler).Methods(http.MethodGet)
 	api.HandleFunc("/{account}/instances/{id}/metrics/graph", s.GetEC2MetricsURLHandler).Methods(http.MethodGet)
 
 	// metrics subrouter - /v1/metrics
@@ -31,10 +30,7 @@ func (s *server) routes() {
 	metricsApi.Handle("/metrics", promhttp.Handler()).Methods(http.MethodGet)
 
 	// metrics endpoints for EC2 instances
-	metricsApi.HandleFunc("/{account}/instances/{id}/graph.png", s.GetEC2MetricsImageHandler).Methods(http.MethodGet)
 	metricsApi.HandleFunc("/{account}/instances/{id}/graph", s.GetEC2MetricsURLHandler).Methods(http.MethodGet)
-
 	// metrics endpoints for ECS services
-	metricsApi.HandleFunc("/{account}/clusters/{cluster}/services/{service}/graph.png", s.GetECSMetricsImageHandler).Methods(http.MethodGet)
 	metricsApi.HandleFunc("/{account}/clusters/{cluster}/services/{service}/graph", s.GetECSMetricsURLHandler).Methods(http.MethodGet)
 }

--- a/cloudwatch/metrics.go
+++ b/cloudwatch/metrics.go
@@ -29,7 +29,7 @@ type MetricsRequest map[string]interface{}
 //   "start": "-P1D",
 //   "end": "PT0H"
 // }
-func (c *Cloudwatch) GetInstanceMetricWidget(ctx context.Context, req MetricsRequest) ([]byte, error) {
+func (c *Cloudwatch) GetMetricWidget(ctx context.Context, req MetricsRequest) ([]byte, error) {
 	if req == nil {
 		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
 	}

--- a/cloudwatch/metrics_test.go
+++ b/cloudwatch/metrics_test.go
@@ -37,14 +37,16 @@ func TestGetMetricWidget(t *testing.T) {
 		t.Errorf("expected nil error reading, got: %s", err)
 	}
 
-	metrics := []Metric{
-		Metric{"AWS/EC2", "CPUUtilization", "InstanceId", "i-abc12345"},
+	req := MetricsRequest{
+		"metrics": []Metric{
+			{"AWS/EC2", "CPUUtilization", "InstanceId", "i-abc12345"},
+		},
+		"period": int64(300),
+		"start":  "-P1D",
+		"end":    "PT0H",
 	}
-	period := int64(300)
-	start := "-P1D"
-	end := "PT0H"
 
-	out, err := c.GetMetricWidget(context.TODO(), metrics, period, start, end)
+	out, err := c.GetMetricWidget(context.TODO(), req)
 	if err != nil {
 		t.Errorf("expected nil error, got: %s", err)
 	}
@@ -53,38 +55,8 @@ func TestGetMetricWidget(t *testing.T) {
 		t.Error("didn't get expected image output from GetMetricWidget")
 	}
 
-	// test nil metric
-	_, err = c.GetMetricWidget(context.TODO(), nil, period, start, end)
-	if aerr, ok := err.(apierror.Error); ok {
-		if aerr.Code != apierror.ErrBadRequest {
-			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
-		}
-	} else {
-		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
-	}
-
-	// test empty period
-	_, err = c.GetMetricWidget(context.TODO(), metrics, 0, start, end)
-	if aerr, ok := err.(apierror.Error); ok {
-		if aerr.Code != apierror.ErrBadRequest {
-			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
-		}
-	} else {
-		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
-	}
-
-	// test empty start
-	_, err = c.GetMetricWidget(context.TODO(), metrics, 300, "", end)
-	if aerr, ok := err.(apierror.Error); ok {
-		if aerr.Code != apierror.ErrBadRequest {
-			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
-		}
-	} else {
-		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
-	}
-
-	// test empty end
-	_, err = c.GetMetricWidget(context.TODO(), metrics, 300, start, "")
+	// test nil metric request
+	_, err = c.GetMetricWidget(context.TODO(), nil)
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrBadRequest {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)

--- a/s3cache/s3cache.go
+++ b/s3cache/s3cache.go
@@ -94,7 +94,7 @@ func (s *S3Cache) GetMetadata(ctx context.Context, key string) ([]byte, error) {
 }
 
 func (s *S3Cache) Save(ctx context.Context, key string, obj []byte) ([]byte, error) {
-	log.Infof("savinvg object %s to cache", key)
+	log.Infof("saving object %s to cache", key)
 
 	if s.Prefix != "" {
 		key = s.Prefix + "/" + key


### PR DESCRIPTION
This moves the metrics to a metrics endpoint (leaving the current endpoint for backwards compatibility for the moment).  It also consolidates query parsing and adds support for container service metrics (which for Fargate, are just CPUUtilization and MemoryUtilization).