### PR TITLE
Surface compute optimizer recommendations for ec2 instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ POST /v1/cost/{account}/spaces/{spaceid}/budgets
 GET /v1/cost/{account}/spaces/{spaceid}/budgets
 DELETE /v1/cost/{account}/spaces/{spaceid}/budgets/{budget}
 
+GET /v1/cost/{account}/spaces/{space}/instances/{id}/optimizer
+
 ### DEPRECATED ###
 GET /v1/cost/{account}/instances/{id}/metrics/graph.png?metric={metric1}[&metric={metric2}&start=-P1D&end=PT0H&period=300]
 GET /v1/cost/{account}/instances/{id}/metrics/graph?metric={metric1}[&metric={metric2}&start=-P1D&end=PT0H&period=300]
@@ -449,6 +451,228 @@ DELETE /v1/cost/{account}/spaces/{spaceid}/budgets/{budget}
 
 ```json
 "OK"
+```
+
+## Compute Optimizer recommendations
+
+### Get recommendations for an instance id
+
+GET /v1/cost/{account}/spaces/{space}/instances/{id}/optimizer
+
+#### Empty response
+
+Empty response is usually a result of not enough data for a recommendation.
+
+```json
+[]
+```
+
+#### Response for optimized instance
+
+```json
+[
+    {
+        "AccountId": "1234567890",
+        "CurrentInstanceType": "t3a.medium",
+        "Finding": "OPTIMIZED",
+        "FindingReasonCodes": [],
+        "InstanceArn": "arn:aws:ec2:us-east-1:1234567890:instance/i-1122334455",
+        "InstanceName": "best.bobs.edu",
+        "LastRefreshTimestamp": "2021-06-16T18:21:42.595Z",
+        "LookBackPeriodInDays": 14,
+        "RecommendationOptions": [
+            {
+                "InstanceType": "t3a.medium",
+                "PerformanceRisk": 1,
+                "PlatformDifferences": [],
+                "ProjectedUtilizationMetrics": [
+                    {
+                        "Name": "CPU",
+                        "Statistic": "MAXIMUM",
+                        "Value": 82.72781814545695
+                    }
+                ],
+                "Rank": 1
+            }
+        ],
+        "RecommendationSources": [
+            {
+                "RecommendationSourceArn": "arn:aws:ec2:us-east-1:1234567890:instance/i-1122334455",
+                "RecommendationSourceType": "Ec2Instance"
+            }
+        ],
+        "UtilizationMetrics": [
+            {
+                "Name": "CPU",
+                "Statistic": "MAXIMUM",
+                "Value": 82.72781814545695
+            },
+            {
+                "Name": "EBS_READ_OPS_PER_SECOND",
+                "Statistic": "MAXIMUM",
+                "Value": 1127.2433333333333
+            },
+            {
+                "Name": "EBS_WRITE_OPS_PER_SECOND",
+                "Statistic": "MAXIMUM",
+                "Value": 74.5
+            },
+            {
+                "Name": "EBS_READ_BYTES_PER_SECOND",
+                "Statistic": "MAXIMUM",
+                "Value": 29981835.9375
+            },
+            {
+                "Name": "EBS_WRITE_BYTES_PER_SECOND",
+                "Statistic": "MAXIMUM",
+                "Value": 1845286.4583333333
+            },
+            {
+                "Name": "NETWORK_IN_BYTES_PER_SECOND",
+                "Statistic": "MAXIMUM",
+                "Value": 10330.019722222223
+            },
+            {
+                "Name": "NETWORK_OUT_BYTES_PER_SECOND",
+                "Statistic": "MAXIMUM",
+                "Value": 507890.63972222223
+            },
+            {
+                "Name": "NETWORK_PACKETS_IN_PER_SECOND",
+                "Statistic": "MAXIMUM",
+                "Value": 39.420111111111105
+            },
+            {
+                "Name": "NETWORK_PACKETS_OUT_PER_SECOND",
+                "Statistic": "MAXIMUM",
+                "Value": 328.95061111111113
+            }
+        ]
+    }
+]
+```
+
+#### Response with recommendations
+
+```json
+[
+    {
+        "AccountId": "1234567890",
+        "CurrentInstanceType": "m4.xlarge",
+        "Finding": "UNDER_PROVISIONED",
+        "FindingReasonCodes": [
+            "CPUOverprovisioned",
+            "EBSIOPSOverprovisioned",
+            "EBSThroughputUnderprovisioned"
+        ],
+        "InstanceArn": "arn:aws:ec2:us-east-1:1234567890:instance/i-0987654321",
+        "InstanceName": "knowledge.bobs.edu",
+        "LastRefreshTimestamp": "2021-06-16T18:53:25.669Z",
+        "LookBackPeriodInDays": 14,
+        "RecommendationOptions": [
+            {
+                "InstanceType": "t3.xlarge",
+                "PerformanceRisk": 3,
+                "PlatformDifferences": [
+                    "NetworkInterface",
+                    "Hypervisor",
+                    "StorageInterface"
+                ],
+                "ProjectedUtilizationMetrics": [
+                    {
+                        "Name": "CPU",
+                        "Statistic": "MAXIMUM",
+                        "Value": 44.64812085482684
+                    }
+                ],
+                "Rank": 1
+            },
+            {
+                "InstanceType": "m5.xlarge",
+                "PerformanceRisk": 1,
+                "PlatformDifferences": [
+                    "NetworkInterface",
+                    "Hypervisor",
+                    "StorageInterface"
+                ],
+                "ProjectedUtilizationMetrics": [
+                    {
+                        "Name": "CPU",
+                        "Statistic": "MAXIMUM",
+                        "Value": 44.64812085482684
+                    }
+                ],
+                "Rank": 2
+            },
+            {
+                "InstanceType": "m4.xlarge",
+                "PerformanceRisk": 1,
+                "PlatformDifferences": [],
+                "ProjectedUtilizationMetrics": [
+                    {
+                        "Name": "CPU",
+                        "Statistic": "MAXIMUM",
+                        "Value": 55.5084745762712
+                    }
+                ],
+                "Rank": 3
+            }
+        ],
+        "RecommendationSources": [
+            {
+                "RecommendationSourceArn": "arn:aws:ec2:us-east-1:1234567890:instance/i-0987654321",
+                "RecommendationSourceType": "Ec2Instance"
+            }
+        ],
+        "UtilizationMetrics": [
+            {
+                "Name": "CPU",
+                "Statistic": "MAXIMUM",
+                "Value": 55.5084745762712
+            },
+            {
+                "Name": "EBS_READ_OPS_PER_SECOND",
+                "Statistic": "MAXIMUM",
+                "Value": 753.56
+            },
+            {
+                "Name": "EBS_WRITE_OPS_PER_SECOND",
+                "Statistic": "MAXIMUM",
+                "Value": 917.98
+            },
+            {
+                "Name": "EBS_READ_BYTES_PER_SECOND",
+                "Statistic": "MAXIMUM",
+                "Value": 89428489.58333333
+            },
+            {
+                "Name": "EBS_WRITE_BYTES_PER_SECOND",
+                "Statistic": "MAXIMUM",
+                "Value": 83148230.79666667
+            },
+            {
+                "Name": "NETWORK_IN_BYTES_PER_SECOND",
+                "Statistic": "MAXIMUM",
+                "Value": 414224.09777777776
+            },
+            {
+                "Name": "NETWORK_OUT_BYTES_PER_SECOND",
+                "Statistic": "MAXIMUM",
+                "Value": 29260.118055555555
+            },
+            {
+                "Name": "NETWORK_PACKETS_IN_PER_SECOND",
+                "Statistic": "MAXIMUM",
+                "Value": 177.9728888888889
+            },
+            {
+                "Name": "NETWORK_PACKETS_OUT_PER_SECOND",
+                "Statistic": "MAXIMUM",
+                "Value": 35.34688888888889
+            }
+        ]
+    }
+]
 ```
 
 ## Metrics Usage

--- a/api/handlers_optimizer.go
+++ b/api/handlers_optimizer.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/YaleSpinup/apierror"
+	"github.com/YaleSpinup/cost-api/computeoptimizer"
+	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
+)
+
+func (s *server) SpaceInstanceOptimizer(w http.ResponseWriter, r *http.Request) {
+	w = LogWriter{w}
+	vars := mux.Vars(r)
+	account := vars["account"]
+	instanceID := vars["id"]
+
+	var j []byte
+	var err error
+	if c, expire, ok := s.optimizerCache.GetWithExpiration(instanceID); ok && c != nil {
+		log.Debugf("found optimizer result for %s in the cache, returning", instanceID)
+
+		w.Header().Set("X-Cache-Hit", "true")
+		w.Header().Set("X-Cache-Expire", fmt.Sprintf("%0.fs", time.Until(expire).Seconds()))
+
+		if j, err = json.Marshal(c); err != nil {
+			log.Errorf("cannot marshal response (%v) into JSON: %s", c, err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	} else {
+		role := fmt.Sprintf("arn:aws:iam::%s:role/%s", account, s.session.RoleName)
+		session, err := s.assumeRole(
+			r.Context(),
+			s.session.ExternalID,
+			role,
+			"",
+			"arn:aws:iam::aws:policy/ComputeOptimizerReadOnlyAccess",
+		)
+		if err != nil {
+			msg := fmt.Sprintf("failed to assume role in account: %s", account)
+			handleError(w, apierror.New(apierror.ErrForbidden, msg, nil))
+			return
+		}
+
+		orch := newOptimizerOrchestrator(
+			computeoptimizer.New(computeoptimizer.WithSession(session.Session)),
+			s.org,
+		)
+
+		out, err := orch.GetInstanceRecommendations(r.Context(), account, instanceID)
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		if j, err = json.Marshal(out); err != nil {
+			log.Errorf("cannot marshal response (%v) into JSON: %s", out, err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		// cache results
+		s.optimizerCache.SetDefault(instanceID, out)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(j)
+}

--- a/api/orchestration_optimizer.go
+++ b/api/orchestration_optimizer.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/computeoptimizer"
+)
+
+func (o *optimizerOrchestrator) GetInstanceRecommendations(ctx context.Context, account, id string) ([]*computeoptimizer.InstanceRecommendation, error) {
+	a := arn.ARN{
+		Partition: "aws",
+		Region:    "us-east-1",
+		AccountID: account,
+		Service:   "ec2",
+		Resource:  fmt.Sprintf("instance/%s", id),
+	}
+
+	out, err := o.client.GetEc2InstanceRecommendations(ctx, a.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}

--- a/api/orchestrators.go
+++ b/api/orchestrators.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"github.com/YaleSpinup/cost-api/budgets"
+	"github.com/YaleSpinup/cost-api/computeoptimizer"
 	"github.com/YaleSpinup/cost-api/sns"
 )
 
@@ -16,5 +17,17 @@ func newBudgetsOrchestrator(budgetsClient *budgets.Budgets, snsClient *sns.SNS, 
 		client:    budgetsClient,
 		snsClient: snsClient,
 		org:       org,
+	}
+}
+
+type optimizerOrchestrator struct {
+	client *computeoptimizer.ComputeOptimizer
+	org    string
+}
+
+func newOptimizerOrchestrator(client *computeoptimizer.ComputeOptimizer, org string) *optimizerOrchestrator {
+	return &optimizerOrchestrator{
+		client: client,
+		org:    org,
 	}
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -23,6 +23,8 @@ func (s *server) routes() {
 	api.HandleFunc("/{account}/spaces/{space}/budgets/{budget}", s.SpaceBudgetsShowHandler).Methods(http.MethodGet)
 	api.HandleFunc("/{account}/spaces/{space}/budgets/{budget}", s.SpaceBudgetsDeleteHandler).Methods(http.MethodDelete)
 
+	api.HandleFunc("/{account}/spaces/{space}/instances/{id}/optimizer", s.SpaceInstanceOptimizer).Methods(http.MethodGet)
+
 	// TODO remove this - these calls are too expensive
 	api.HandleFunc("/{account}/spaces/{space}/{resourcename}", s.SpaceResourceGetHandler).Methods(http.MethodGet).MatcherFunc(matchSpaceQueries)
 

--- a/api/server.go
+++ b/api/server.go
@@ -28,6 +28,7 @@ type server struct {
 	cloudwatchServices   map[string]cloudwatch.Cloudwatch
 	session              session.Session
 	orgPolicy            string
+	optimizerCache       *cache.Cache
 	resultCache          map[string]*cache.Cache
 	imageCache           imagecache.ImageCache
 	org                  string
@@ -82,6 +83,9 @@ func NewServer(config common.Config) error {
 		log.Error("Unexpected error with configured purgetime")
 		return err
 	}
+
+	log.Debugf("creating new optimizer cache with expire time: %s and purge time: %s", expireTime.String(), purgeTime.String())
+	s.optimizerCache = cache.New(expireTime, purgeTime)
 
 	// Create shared cost explorer sessions, cloudwatch sessions, and go-cache instances per account defined in the config
 	for name, c := range config.Accounts {

--- a/computeoptimizer/computeoptimizer.go
+++ b/computeoptimizer/computeoptimizer.go
@@ -1,0 +1,71 @@
+package computeoptimizer
+
+import (
+	"context"
+
+	"github.com/YaleSpinup/apierror"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/computeoptimizer"
+	"github.com/aws/aws-sdk-go/service/computeoptimizer/computeoptimizeriface"
+	log "github.com/sirupsen/logrus"
+)
+
+type ComputeOptimizer struct {
+	session *session.Session
+	Service computeoptimizeriface.ComputeOptimizerAPI
+}
+
+type ComputeOptimizerOption func(*ComputeOptimizer)
+
+func New(opts ...ComputeOptimizerOption) *ComputeOptimizer {
+	client := ComputeOptimizer{}
+
+	for _, opt := range opts {
+		opt(&client)
+	}
+
+	if client.session != nil {
+		client.Service = computeoptimizer.New(client.session)
+	}
+
+	return &client
+}
+
+func WithSession(sess *session.Session) ComputeOptimizerOption {
+	return func(client *ComputeOptimizer) {
+		log.Debug("using aws session")
+		client.session = sess
+	}
+}
+
+func WithCredentials(key, secret, token, region string) ComputeOptimizerOption {
+	return func(client *ComputeOptimizer) {
+		log.Debugf("creating new session with key id %s in region %s", key, region)
+		sess := session.Must(session.NewSession(&aws.Config{
+			Credentials: credentials.NewStaticCredentials(key, secret, token),
+			Region:      aws.String(region),
+		}))
+		client.session = sess
+	}
+}
+
+func (c *ComputeOptimizer) GetEc2InstanceRecommendations(ctx context.Context, arn string) ([]*computeoptimizer.InstanceRecommendation, error) {
+	if arn == "" {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	log.Infof("getting recommendations for ec2 instance %s", arn)
+
+	out, err := c.Service.GetEC2InstanceRecommendationsWithContext(ctx, &computeoptimizer.GetEC2InstanceRecommendationsInput{
+		InstanceArns: aws.StringSlice([]string{arn}),
+	})
+	if err != nil {
+		return nil, ErrCode("failed to get instance recommendations", err)
+	}
+
+	log.Debugf("got output from ec2 instance recommendations for %s: %+v", arn, out)
+
+	return out.InstanceRecommendations, nil
+}

--- a/computeoptimizer/computeoptimizer_test.go
+++ b/computeoptimizer/computeoptimizer_test.go
@@ -1,0 +1,243 @@
+package computeoptimizer
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/computeoptimizer"
+	"github.com/aws/aws-sdk-go/service/computeoptimizer/computeoptimizeriface"
+)
+
+// mockComputeOptimizerClient is a fake computeoptimizer client
+type mockComputeOptimizerClient struct {
+	computeoptimizeriface.ComputeOptimizerAPI
+	t   *testing.T
+	err error
+}
+
+func newMockComputeOptimizerClient(t *testing.T, err error) computeoptimizeriface.ComputeOptimizerAPI {
+	return &mockComputeOptimizerClient{
+		t:   t,
+		err: err,
+	}
+}
+
+func TestNewSession(t *testing.T) {
+	client := New()
+	to := reflect.TypeOf(client).String()
+	if to != "*computeoptimizer.ComputeOptimizer" {
+		t.Errorf("expected type to be '*computeoptimizer.ComputeOptimizer', got %s", to)
+	}
+}
+
+var recommendation = `
+[
+    {
+        "AccountId": "1234567890",
+        "CurrentInstanceType": "m4.xlarge",
+        "Finding": "UNDER_PROVISIONED",
+        "FindingReasonCodes": [
+            "CPUOverprovisioned",
+            "EBSIOPSOverprovisioned",
+            "EBSThroughputUnderprovisioned"
+        ],
+        "InstanceArn": "arn:aws:ec2:us-east-1:1234567890:instance/i-0987654321",
+        "InstanceName": "knowledge.bobs.edu",
+        "LastRefreshTimestamp": "2021-06-16T18:53:25.669Z",
+        "LookBackPeriodInDays": 14,
+        "RecommendationOptions": [
+            {
+                "InstanceType": "t3.xlarge",
+                "PerformanceRisk": 3,
+                "PlatformDifferences": [
+                    "NetworkInterface",
+                    "Hypervisor",
+                    "StorageInterface"
+                ],
+                "ProjectedUtilizationMetrics": [
+                    {
+                        "Name": "CPU",
+                        "Statistic": "MAXIMUM",
+                        "Value": 44.64812085482684
+                    }
+                ],
+                "Rank": 1
+            },
+            {
+                "InstanceType": "m5.xlarge",
+                "PerformanceRisk": 1,
+                "PlatformDifferences": [
+                    "NetworkInterface",
+                    "Hypervisor",
+                    "StorageInterface"
+                ],
+                "ProjectedUtilizationMetrics": [
+                    {
+                        "Name": "CPU",
+                        "Statistic": "MAXIMUM",
+                        "Value": 44.64812085482684
+                    }
+                ],
+                "Rank": 2
+            },
+            {
+                "InstanceType": "m4.xlarge",
+                "PerformanceRisk": 1,
+                "PlatformDifferences": [],
+                "ProjectedUtilizationMetrics": [
+                    {
+                        "Name": "CPU",
+                        "Statistic": "MAXIMUM",
+                        "Value": 55.5084745762712
+                    }
+                ],
+                "Rank": 3
+            }
+        ],
+        "RecommendationSources": [
+            {
+                "RecommendationSourceArn": "arn:aws:ec2:us-east-1:1234567890:instance/i-0987654321",
+                "RecommendationSourceType": "Ec2Instance"
+            }
+        ],
+        "UtilizationMetrics": [
+            {
+                "Name": "CPU",
+                "Statistic": "MAXIMUM",
+                "Value": 55.5084745762712
+            },
+            {
+                "Name": "EBS_READ_OPS_PER_SECOND",
+                "Statistic": "MAXIMUM",
+                "Value": 753.56
+            },
+            {
+                "Name": "EBS_WRITE_OPS_PER_SECOND",
+                "Statistic": "MAXIMUM",
+                "Value": 917.98
+            },
+            {
+                "Name": "EBS_READ_BYTES_PER_SECOND",
+                "Statistic": "MAXIMUM",
+                "Value": 89428489.58333333
+            },
+            {
+                "Name": "EBS_WRITE_BYTES_PER_SECOND",
+                "Statistic": "MAXIMUM",
+                "Value": 83148230.79666667
+            },
+            {
+                "Name": "NETWORK_IN_BYTES_PER_SECOND",
+                "Statistic": "MAXIMUM",
+                "Value": 414224.09777777776
+            },
+            {
+                "Name": "NETWORK_OUT_BYTES_PER_SECOND",
+                "Statistic": "MAXIMUM",
+                "Value": 29260.118055555555
+            },
+            {
+                "Name": "NETWORK_PACKETS_IN_PER_SECOND",
+                "Statistic": "MAXIMUM",
+                "Value": 177.9728888888889
+            },
+            {
+                "Name": "NETWORK_PACKETS_OUT_PER_SECOND",
+                "Statistic": "MAXIMUM",
+                "Value": 35.34688888888889
+            }
+        ]
+    }
+]
+`
+
+func unmarshallreq(req string) []*computeoptimizer.InstanceRecommendation {
+	reqs := []*computeoptimizer.InstanceRecommendation{}
+	json.Unmarshal([]byte(recommendation), &reqs)
+	return reqs
+}
+
+func (m mockComputeOptimizerClient) GetEC2InstanceRecommendationsWithContext(ctx context.Context, input *computeoptimizer.GetEC2InstanceRecommendationsInput, opts ...request.Option) (*computeoptimizer.GetEC2InstanceRecommendationsOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	reqs := []*computeoptimizer.InstanceRecommendation{}
+	if aws.StringValue(input.InstanceArns[0]) == "arn:aws:ec2:us-east-1:1234567890:instance/i-0987654321" {
+		reqs = unmarshallreq(recommendation)
+	}
+
+	return &computeoptimizer.GetEC2InstanceRecommendationsOutput{
+		Errors:                  []*computeoptimizer.GetRecommendationError{},
+		InstanceRecommendations: reqs,
+	}, nil
+}
+
+func TestComputeOptimizer_GetEc2InstanceRecommendations(t *testing.T) {
+	type fields struct {
+		session *session.Session
+		Service computeoptimizeriface.ComputeOptimizerAPI
+	}
+	type args struct {
+		ctx context.Context
+		arn string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    []*computeoptimizer.InstanceRecommendation
+		wantErr bool
+	}{
+		{
+			name: "empty input",
+			args: args{
+				ctx: context.TODO(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "recommendations",
+			fields: fields{
+				Service: newMockComputeOptimizerClient(t, nil),
+			},
+			args: args{
+				ctx: context.TODO(),
+				arn: "arn:aws:ec2:us-east-1:1234567890:instance/i-0987654321",
+			},
+			want: unmarshallreq(recommendation),
+		},
+		{
+			name: "empty recommendations",
+			fields: fields{
+				Service: newMockComputeOptimizerClient(t, nil),
+			},
+			args: args{
+				ctx: context.TODO(),
+				arn: "foobar",
+			},
+			want: []*computeoptimizer.InstanceRecommendation{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &ComputeOptimizer{
+				session: tt.fields.session,
+				Service: tt.fields.Service,
+			}
+			got, err := c.GetEc2InstanceRecommendations(tt.args.ctx, tt.args.arn)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ComputeOptimizer.GetEc2InstanceRecommendations() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ComputeOptimizer.GetEc2InstanceRecommendations() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/computeoptimizer/errors.go
+++ b/computeoptimizer/errors.go
@@ -1,0 +1,98 @@
+package computeoptimizer
+
+import (
+	"github.com/YaleSpinup/apierror"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/computeoptimizer"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+func ErrCode(msg string, err error) error {
+	if aerr, ok := errors.Cause(err).(awserr.Error); ok {
+		switch aerr.Code() {
+		case
+			// ErrCodeAccessDeniedException for service response error code
+			// "AccessDeniedException".
+			//
+			// You do not have sufficient access to perform this action.
+			computeoptimizer.ErrCodeAccessDeniedException,
+
+			// ErrCodeMissingAuthenticationToken for service response error code
+			// "MissingAuthenticationToken".
+			//
+			// The request must contain either a valid (registered) AWS access key ID or
+			// X.509 certificate.
+			computeoptimizer.ErrCodeMissingAuthenticationToken:
+
+			return apierror.New(apierror.ErrForbidden, msg, aerr)
+		case
+
+			// ErrCodeResourceNotFoundException for service response error code
+			// "ResourceNotFoundException".
+			//
+			// A resource that is required for the action doesn't exist.
+			computeoptimizer.ErrCodeResourceNotFoundException:
+
+			return apierror.New(apierror.ErrNotFound, msg, aerr)
+
+		case
+
+			"Conflict":
+
+			return apierror.New(apierror.ErrConflict, msg, aerr)
+
+		case
+
+			// ErrCodeInvalidParameterValueException for service response error code
+			// "InvalidParameterValueException".
+			//
+			// An invalid or out-of-range value was supplied for the input parameter.
+			computeoptimizer.ErrCodeInvalidParameterValueException,
+
+			// ErrCodeOptInRequiredException for service response error code
+			// "OptInRequiredException".
+			//
+			// The account is not opted in to AWS Compute Optimizer.
+			computeoptimizer.ErrCodeOptInRequiredException,
+
+			// ErrCodeServiceUnavailableException for service response error code
+			// "ServiceUnavailableException".
+			//
+			// The request has failed due to a temporary failure of the server.
+			computeoptimizer.ErrCodeServiceUnavailableException:
+
+			return apierror.New(apierror.ErrBadRequest, msg, aerr)
+		case
+
+			// ErrCodeLimitExceededException for service response error code
+			// "LimitExceededException".
+			//
+			// The request exceeds a limit of the service.
+			computeoptimizer.ErrCodeLimitExceededException,
+
+			// ErrCodeThrottlingException for service response error code
+			// "ThrottlingException".
+			//
+			// The request was denied due to request throttling.
+			computeoptimizer.ErrCodeThrottlingException:
+
+			return apierror.New(apierror.ErrLimitExceeded, msg, aerr)
+		case
+
+			// ErrCodeInternalServerException for service response error code
+			// "InternalServerException".
+			//
+			// An internal error has occurred. Try your call again.
+			computeoptimizer.ErrCodeInternalServerException:
+
+			return apierror.New(apierror.ErrServiceUnavailable, msg, aerr)
+		default:
+			m := msg + ": " + aerr.Message()
+			return apierror.New(apierror.ErrBadRequest, m, aerr)
+		}
+	}
+
+	log.Warnf("uncaught error: %s, returning Internal Server Error", err)
+	return apierror.New(apierror.ErrInternalError, msg, err)
+}


### PR DESCRIPTION
Surfaces compute optimizer recommendations for EC2 (if there are any). Empty response for instances without any recommendations (not enough data - 14d) and OPTIMIZED for instances that are already optimized. 