### PR TITLE
Add inventory endpoint and support for pulling details about resources by spaceid

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ GET /v1/cost/{account}/instances/{id}/metrics/graph.png?metric={metric1}[&metric
 GET /v1/cost/{account}/instances/{id}/metrics/graph?metric={metric1}[&metric={metric2}&start=-P1D&end=PT0H&period=300]
 ##################
 
+GET /v1/inventory/{account}/spaces/{spaceid}
+
 GET /v1/metrics/{account}/instances/{id}/graph?metric={metric1}[&metric={metric2}&start=-P1D&end=PT0H&period=300]
 GET /v1/metrics/{account}/clusters/{cluster}/services/{service}/graph?metric={metric1}[&metric={metric2}&start=-P1D&end=PT0H&period=300]
 GET /v1/metrics/{account}/buckets/{bucket}/graph?metric={BucketSizeBytes|NumberOfObjects}
@@ -674,6 +676,60 @@ Empty response is usually a result of not enough data for a recommendation.
     }
 ]
 ```
+
+## Inventory Usage
+
+The inventory endpoint returns resources belonging to a space by tag.  It uses the resourcegroupstaggingapi and also parses the ARN to
+determine the resource type information.  Since the `resource` prefix is inconsistent, it shouldn't be relied upon for categorization, but the
+`service` should be accurate.
+
+### Request
+
+GET /v1/inventory/{account}/spaces/{spaceid}
+
+### Response
+
+```json
+[
+    {
+        "name": "spintst-000a16-TestFS",
+        "arn": "arn:aws:elasticfilesystem:us-east-1:1234567890:file-system/fs-aaaabbbb11",
+        "partition": "aws",
+        "service": "elasticfilesystem",
+        "region": "us-east-1",
+        "account_id": "1234567890",
+        "resource": "file-system/fs-aaaabbbb11"
+    },
+    {
+        "name": "",
+        "arn": "arn:aws:elasticloadbalancing:us-east-1:1234567890:targetgroup/testTargetGroup-HTTP80/abcdefg12",
+        "partition": "aws",
+        "service": "elasticloadbalancing",
+        "region": "us-east-1",
+        "account_id": "1234567890",
+        "resource": "targetgroup/testTargetGroup-HTTP80/abcdefg12"
+    },
+    {
+        "name": "spintst-000028",
+        "arn": "arn:aws:logs:us-east-1:1234567890:log-group:spintst-000028",
+        "partition": "aws",
+        "service": "logs",
+        "region": "us-east-1",
+        "account_id": "1234567890",
+        "resource": "log-group:spintst-000028"
+    },
+    {
+        "name": "spintst-000b67-webServiceTest",
+        "arn": "arn:aws:secretsmanager:us-east-1:1234567890:secret:spinup/sstst/spintst-000028/spintst-000b67-webServiceTest-api-cred-ibdIk7",
+        "partition": "aws",
+        "service": "secretsmanager",
+        "region": "us-east-1",
+        "account_id": "1234567890",
+        "resource": "secret:spinup/sstst/spintst-000028/spintst-000b67-webServiceTest-api-cred-ibdIk7"
+    }
+]
+```
+
 
 ## Metrics Usage
 

--- a/api/handlers_inventory.go
+++ b/api/handlers_inventory.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/YaleSpinup/apierror"
+	"github.com/YaleSpinup/cost-api/resourcegroupstaggingapi"
+	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
+)
+
+// SpaceInventoryGetHandler handles getting the inventory for resources with a spaceid
+func (s *server) SpaceInventoryGetHandler(w http.ResponseWriter, r *http.Request) {
+	w = LogWriter{w}
+	vars := mux.Vars(r)
+	account := vars["account"]
+	spaceID := vars["space"]
+
+	role := fmt.Sprintf("arn:aws:iam::%s:role/%s", account, s.session.RoleName)
+	session, err := s.assumeRole(
+		r.Context(),
+		s.session.ExternalID,
+		role,
+		"",
+		"arn:aws:iam::aws:policy/AWSResourceGroupsReadOnlyAccess",
+	)
+	if err != nil {
+		msg := fmt.Sprintf("failed to assume role in account: %s", account)
+		handleError(w, apierror.New(apierror.ErrForbidden, msg, nil))
+		return
+	}
+
+	orch := newInventoryOrchestrator(
+		resourcegroupstaggingapi.New(resourcegroupstaggingapi.WithSession(session.Session)),
+		s.org,
+	)
+
+	out, err := orch.GetResourceInventory(r.Context(), account, spaceID)
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+
+	j, err := json.Marshal(out)
+	if err != nil {
+		log.Errorf("cannot marshal response (%v) into JSON: %s", out, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("X-Items", strconv.Itoa(len(out)))
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(j)
+}

--- a/api/orchestration_inventory.go
+++ b/api/orchestration_inventory.go
@@ -1,0 +1,50 @@
+package api
+
+import (
+	"context"
+
+	"github.com/YaleSpinup/apierror"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	log "github.com/sirupsen/logrus"
+)
+
+func (o *inventoryOrchestrator) GetResourceInventory(ctx context.Context, account, spaceid string) ([]*InventoryResponse, error) {
+	if spaceid == "" {
+		return nil, apierror.New(apierror.ErrBadRequest, "spaceid is required", nil)
+	}
+
+	list := []*InventoryResponse{}
+	input := resourcegroupstaggingapi.GetResourcesInput{
+		TagFilters: []*resourcegroupstaggingapi.TagFilter{
+			{
+				Key:    aws.String("spinup:spaceid"),
+				Values: []*string{aws.String(spaceid)},
+			},
+		},
+		ResourcesPerPage: aws.Int64(100),
+	}
+
+	for {
+		out, err := o.client.ListResourcesWithTags(ctx, &input)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, res := range out.ResourceTagMappingList {
+			list = append(list, toInventoryResponse(res))
+		}
+
+		log.Debugf("%+v:%s", out.PaginationToken, aws.StringValue(out.PaginationToken))
+
+		if aws.StringValue(out.PaginationToken) == "" {
+			break
+		}
+
+		input.PaginationToken = out.PaginationToken
+
+		log.Debugf("%d resources in list", len(list))
+	}
+
+	return list, nil
+}

--- a/api/orchestrators.go
+++ b/api/orchestrators.go
@@ -3,6 +3,7 @@ package api
 import (
 	"github.com/YaleSpinup/cost-api/budgets"
 	"github.com/YaleSpinup/cost-api/computeoptimizer"
+	"github.com/YaleSpinup/cost-api/resourcegroupstaggingapi"
 	"github.com/YaleSpinup/cost-api/sns"
 )
 
@@ -27,6 +28,18 @@ type optimizerOrchestrator struct {
 
 func newOptimizerOrchestrator(client *computeoptimizer.ComputeOptimizer, org string) *optimizerOrchestrator {
 	return &optimizerOrchestrator{
+		client: client,
+		org:    org,
+	}
+}
+
+type inventoryOrchestrator struct {
+	client *resourcegroupstaggingapi.ResourceGroupsTaggingAPI
+	org    string
+}
+
+func newInventoryOrchestrator(client *resourcegroupstaggingapi.ResourceGroupsTaggingAPI, org string) *inventoryOrchestrator {
+	return &inventoryOrchestrator{
 		client: client,
 		org:    org,
 	}

--- a/api/routes.go
+++ b/api/routes.go
@@ -46,6 +46,14 @@ func (s *server) routes() {
 	metricsApi.HandleFunc("/{account}/buckets/{bucket}/graph", s.GetS3MetricsURLHandler).Queries("metric", "{metric:(?:BucketSizeBytes|NumberOfObjects)}").Methods(http.MethodGet)
 	// metrics endpoints for RDS services
 	metricsApi.HandleFunc("/{account}/rds/{type}/{id}/graph", s.GetRDSMetricsURLHandler).Methods(http.MethodGet)
+
+	inventoryApi := s.router.PathPrefix("/v1/inventory").Subrouter()
+	inventoryApi.HandleFunc("/ping", s.PingHandler).Methods(http.MethodGet)
+	inventoryApi.HandleFunc("/version", s.VersionHandler).Methods(http.MethodGet)
+	inventoryApi.Handle("/metrics", promhttp.Handler()).Methods(http.MethodGet)
+
+	// inventory endpoints for a space
+	inventoryApi.HandleFunc("/{account}/spaces/{space}", s.SpaceInventoryGetHandler).Methods(http.MethodGet)
 }
 
 // custom matcher for space queries

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -15,6 +15,6 @@ ingress:
   enabled: true
   annotations: {}
   rules:
-    - paths: ['/v1/cost', '/v1/metrics']
+    - paths: ['/v1/cost', '/v1/metrics', '/v1/inventory']
 
 probePath: '/v1/cost/ping'

--- a/resourcegroupstaggingapi/errors.go
+++ b/resourcegroupstaggingapi/errors.go
@@ -1,0 +1,97 @@
+package resourcegroupstaggingapi
+
+import (
+	"github.com/YaleSpinup/apierror"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/pkg/errors"
+)
+
+func ErrCode(msg string, err error) error {
+	if aerr, ok := errors.Cause(err).(awserr.Error); ok {
+		switch aerr.Code() {
+		case
+
+			// ErrCodeInternalServiceException for service response error code
+			// "InternalServiceException".
+			//
+			// The request processing failed because of an unknown error, exception, or
+			// failure. You can retry the request.
+			resourcegroupstaggingapi.ErrCodeInternalServiceException:
+
+			return apierror.New(apierror.ErrInternalError, msg, err)
+		case
+
+			// ErrCodeConcurrentModificationException for service response error code
+			// "ConcurrentModificationException".
+			//
+			// The target of the operation is currently being modified by a different request.
+			// Try again later.
+			resourcegroupstaggingapi.ErrCodeConcurrentModificationException,
+
+			// ErrCodeThrottledException for service response error code
+			// "ThrottledException".
+			//
+			// The request was denied to limit the frequency of submitted requests.
+			resourcegroupstaggingapi.ErrCodeThrottledException:
+			return apierror.New(apierror.ErrConflict, msg, aerr)
+		case
+
+			// ErrCodeConstraintViolationException for service response error code
+			// "ConstraintViolationException".
+			//
+			// The request was denied because performing this operation violates a constraint.
+			//
+			// Some of the reasons in the following list might not apply to this specific
+			// operation.
+			//
+			//    * You must meet the prerequisites for using tag policies. For information,
+			//    see Prerequisites and Permissions for Using Tag Policies (http://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_tag-policies-prereqs.html)
+			//    in the AWS Organizations User Guide.
+			//
+			//    * You must enable the tag policies service principal (tagpolicies.tag.amazonaws.com)
+			//    to integrate with AWS Organizations For information, see EnableAWSServiceAccess
+			//    (http://docs.aws.amazon.com/organizations/latest/APIReference/API_EnableAWSServiceAccess.html).
+			//
+			//    * You must have a tag policy attached to the organization root, an OU,
+			//    or an account.
+			resourcegroupstaggingapi.ErrCodeConstraintViolationException,
+
+			// ErrCodeInvalidParameterException for service response error code
+			// "InvalidParameterException".
+			//
+			// This error indicates one of the following:
+			//
+			//    * A parameter is missing.
+			//
+			//    * A malformed string was supplied for the request parameter.
+			//
+			//    * An out-of-range value was supplied for the request parameter.
+			//
+			//    * The target ID is invalid, unsupported, or doesn't exist.
+			//
+			//    * You can't access the Amazon S3 bucket for report storage. For more information,
+			//    see Additional Requirements for Organization-wide Tag Compliance Reports
+			//    (http://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_tag-policies-prereqs.html#bucket-policies-org-report)
+			//    in the AWS Organizations User Guide.
+			resourcegroupstaggingapi.ErrCodeInvalidParameterException,
+
+			// ErrCodePaginationTokenExpiredException for service response error code
+			// "PaginationTokenExpiredException".
+			//
+			// A PaginationToken is valid for a maximum of 15 minutes. Your request was
+			// denied because the specified PaginationToken has expired.
+			resourcegroupstaggingapi.ErrCodePaginationTokenExpiredException:
+
+			return apierror.New(apierror.ErrBadRequest, msg, aerr)
+		case
+			"Not Found":
+			return apierror.New(apierror.ErrNotFound, msg, aerr)
+		default:
+			m := msg + ": " + aerr.Message()
+			return apierror.New(apierror.ErrBadRequest, m, aerr)
+		}
+	}
+
+	return apierror.New(apierror.ErrInternalError, msg, err)
+}

--- a/resourcegroupstaggingapi/errors_test.go
+++ b/resourcegroupstaggingapi/errors_test.go
@@ -1,0 +1,38 @@
+package resourcegroupstaggingapi
+
+import (
+	"testing"
+
+	"github.com/YaleSpinup/apierror"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/pkg/errors"
+)
+
+func TestErrCode(t *testing.T) {
+	apiErrorTestCases := map[string]string{
+		"": apierror.ErrBadRequest,
+		resourcegroupstaggingapi.ErrCodeInternalServiceException:        apierror.ErrInternalError,
+		resourcegroupstaggingapi.ErrCodeConcurrentModificationException: apierror.ErrConflict,
+		resourcegroupstaggingapi.ErrCodeThrottledException:              apierror.ErrConflict,
+		resourcegroupstaggingapi.ErrCodeConstraintViolationException:    apierror.ErrBadRequest,
+		resourcegroupstaggingapi.ErrCodeInvalidParameterException:       apierror.ErrBadRequest,
+		resourcegroupstaggingapi.ErrCodePaginationTokenExpiredException: apierror.ErrBadRequest,
+	}
+
+	for awsErr, apiErr := range apiErrorTestCases {
+		err := ErrCode("test error", awserr.New(awsErr, awsErr, nil))
+		if aerr, ok := errors.Cause(err).(apierror.Error); ok {
+			t.Logf("got apierror '%s'", aerr)
+		} else {
+			t.Errorf("expected resourcegroupstaggingapi error %s to be an apierror.Error %s, got %s", awsErr, apiErr, err)
+		}
+	}
+
+	err := ErrCode("test error", errors.New("Unknown"))
+	if aerr, ok := errors.Cause(err).(apierror.Error); ok {
+		t.Logf("got apierror '%s'", aerr)
+	} else {
+		t.Errorf("expected unknown error to be an apierror.ErrInternalError, got %s", err)
+	}
+}

--- a/resourcegroupstaggingapi/resourcegroupstaggingapi.go
+++ b/resourcegroupstaggingapi/resourcegroupstaggingapi.go
@@ -1,0 +1,70 @@
+package resourcegroupstaggingapi
+
+import (
+	"context"
+
+	"github.com/YaleSpinup/apierror"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface"
+	log "github.com/sirupsen/logrus"
+)
+
+// ResourceGroupsTaggingAPI is a wrapper around the aws resourcegroupstaggingapi service with some default config info
+type ResourceGroupsTaggingAPI struct {
+	session *session.Session
+	Service resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI
+}
+
+type ResourceGroupsTaggingAPIOption func(*ResourceGroupsTaggingAPI)
+
+func New(opts ...ResourceGroupsTaggingAPIOption) *ResourceGroupsTaggingAPI {
+	client := ResourceGroupsTaggingAPI{}
+
+	for _, opt := range opts {
+		opt(&client)
+	}
+
+	if client.session != nil {
+		client.Service = resourcegroupstaggingapi.New(client.session)
+	}
+
+	return &client
+}
+
+func WithSession(sess *session.Session) ResourceGroupsTaggingAPIOption {
+	return func(client *ResourceGroupsTaggingAPI) {
+		log.Debug("using aws session")
+		client.session = sess
+	}
+}
+
+func WithCredentials(key, secret, token, region string) ResourceGroupsTaggingAPIOption {
+	return func(client *ResourceGroupsTaggingAPI) {
+		log.Debugf("creating new session with key id %s in region %s", key, region)
+		sess := session.Must(session.NewSession(&aws.Config{
+			Credentials: credentials.NewStaticCredentials(key, secret, token),
+			Region:      aws.String(region),
+		}))
+		client.session = sess
+	}
+}
+
+func (r *ResourceGroupsTaggingAPI) ListResourcesWithTags(ctx context.Context, input *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+	if input == nil {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	log.Info("listing tagged resources")
+
+	out, err := r.Service.GetResourcesWithContext(ctx, input)
+	if err != nil {
+		return nil, ErrCode("listing resource with tags", err)
+	}
+
+	log.Debugf("got output from get resources: %+v", out)
+
+	return out, nil
+}

--- a/resourcegroupstaggingapi/resourcegroupstaggingapi_test.go
+++ b/resourcegroupstaggingapi/resourcegroupstaggingapi_test.go
@@ -1,0 +1,205 @@
+package resourcegroupstaggingapi
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface"
+)
+
+// mockResourceGroupsTaggingAPIClient is a fake resourcegroupstaggingapi client
+type mockResourceGroupsTaggingAPIClient struct {
+	resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI
+	t   *testing.T
+	err error
+}
+
+func newmockResourceGroupsTaggingAPIClient(t *testing.T, err error) resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI {
+	return &mockResourceGroupsTaggingAPIClient{
+		t:   t,
+		err: err,
+	}
+}
+
+func TestNewSession(t *testing.T) {
+	client := New()
+	to := reflect.TypeOf(client).String()
+	if to != "*resourcegroupstaggingapi.ResourceGroupsTaggingAPI" {
+		t.Errorf("expected type to be '*resourcegroupstaggingapi.ResourceGroupsTaggingAPI', got %s", to)
+	}
+}
+
+type tag struct {
+	key   string
+	value string
+}
+
+type testResource struct {
+	resourceType string
+	tags         []tag
+	arn          string
+}
+
+var testResources = []testResource{
+	{
+		resourceType: "ec2:instance",
+		tags: []tag{
+			{
+				key:   "spinup:org",
+				value: "foobar",
+			},
+			{
+				key:   "spinup:spaceid",
+				value: "123",
+			},
+		},
+		arn: "arn:aws:ec2:us-east-1:1234567890:instance/i-0987654321",
+	},
+	{
+		resourceType: "elasticloadbalancing:targetgroup",
+		tags: []tag{
+			{
+				key:   "spinup:org",
+				value: "foobar",
+			},
+			{
+				key:   "spinup:spaceid",
+				value: "123",
+			},
+		},
+		arn: "arn:aws:elasticloadbalancing:us-east-1:1234567890:targetgroup/testtg123/0987654321",
+	},
+	{
+		resourceType: "elasticloadbalancing:targetgroup",
+		tags: []tag{
+			{
+				key:   "spinup:org",
+				value: "foobar",
+			},
+			{
+				key:   "spinup:spaceid",
+				value: "321",
+			},
+		},
+		arn: "arn:aws:elasticloadbalancing:us-east-1:1234567890:targetgroup/testtg321/0987654321",
+	},
+}
+
+func (m *mockResourceGroupsTaggingAPIClient) GetResourcesWithContext(ctx context.Context, input *resourcegroupstaggingapi.GetResourcesInput, opts ...request.Option) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	resourceList := []*resourcegroupstaggingapi.ResourceTagMapping{}
+	for _, r := range testResources {
+		if len(input.ResourceTypeFilters) > 0 {
+			var typeMatch bool
+			for _, t := range input.ResourceTypeFilters {
+				if aws.StringValue(t) == r.resourceType {
+					typeMatch = true
+					break
+				}
+			}
+
+			if !typeMatch {
+				continue
+			}
+		}
+
+		matches := true
+		for _, filter := range input.TagFilters {
+			innerMatch := func() bool {
+				m.t.Logf("processing tagfilter %+v", filter)
+				for _, rt := range r.tags {
+					if aws.StringValue(filter.Key) == rt.key {
+						m.t.Logf("tag keys match for %s (%s = %s)", r.arn, rt.key, aws.StringValue(filter.Key))
+						if len(filter.Values) == 0 {
+							m.t.Logf("appending %s to the list, keys match (%s = %s) and no value specified", r.arn, rt.key, aws.StringValue(filter.Key))
+							return true
+						}
+
+						for _, value := range aws.StringValueSlice(filter.Values) {
+							if value == rt.value {
+								m.t.Logf("appending %s to the list, keys match (%s = %s) and value matches (%s = %s)", r.arn, rt.key, aws.StringValue(filter.Key), value, rt.value)
+								return true
+							}
+						}
+					}
+				}
+				m.t.Logf("returning false for %s", r.arn)
+				return false
+			}()
+
+			if !innerMatch {
+				matches = false
+			}
+		}
+
+		if matches {
+			m.t.Logf("resource %s matches", r.arn)
+			resourceList = append(resourceList, &resourcegroupstaggingapi.ResourceTagMapping{
+				ResourceARN: aws.String(r.arn),
+			})
+		}
+	}
+
+	return &resourcegroupstaggingapi.GetResourcesOutput{
+		ResourceTagMappingList: resourceList,
+	}, nil
+}
+
+func TestListResourcesWithTags(t *testing.T) {
+	r := ResourceGroupsTaggingAPI{Service: newmockResourceGroupsTaggingAPIClient(t, nil)}
+	out, err := r.ListResourcesWithTags(context.TODO(), &resourcegroupstaggingapi.GetResourcesInput{
+		ResourceTypeFilters: aws.StringSlice([]string{"elasticloadbalancing:targetgroup"}),
+		TagFilters: []*resourcegroupstaggingapi.TagFilter{
+			{Key: aws.String("spinup:org"), Values: aws.StringSlice([]string{"foobar"})},
+			{Key: aws.String("spinup:spaceid"), Values: aws.StringSlice([]string{"123"})},
+		},
+	})
+
+	if err != nil {
+		t.Errorf("expected no error, got %s", err)
+	}
+
+	expected := &resourcegroupstaggingapi.GetResourcesOutput{
+		ResourceTagMappingList: []*resourcegroupstaggingapi.ResourceTagMapping{
+			{
+				ResourceARN: aws.String("arn:aws:elasticloadbalancing:us-east-1:1234567890:targetgroup/testtg123/0987654321"),
+			},
+		},
+	}
+	if !reflect.DeepEqual(expected, out) {
+		t.Errorf("expected %+v, got %+v", expected, out)
+	}
+
+	out, err = r.ListResourcesWithTags(context.TODO(), &resourcegroupstaggingapi.GetResourcesInput{
+		TagFilters: []*resourcegroupstaggingapi.TagFilter{
+			{Key: aws.String("spinup:org"), Values: aws.StringSlice([]string{"foobar"})},
+			{Key: aws.String("spinup:spaceid"), Values: aws.StringSlice([]string{"123"})},
+		},
+	})
+
+	if err != nil {
+		t.Errorf("expected no error, got %s", err)
+	}
+
+	expected = &resourcegroupstaggingapi.GetResourcesOutput{
+		ResourceTagMappingList: []*resourcegroupstaggingapi.ResourceTagMapping{
+			{
+				ResourceARN: aws.String("arn:aws:ec2:us-east-1:1234567890:instance/i-0987654321"),
+			},
+			{
+				ResourceARN: aws.String("arn:aws:elasticloadbalancing:us-east-1:1234567890:targetgroup/testtg123/0987654321"),
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(expected, out) {
+		t.Errorf("expected %+v, got %+v", expected, out)
+	}
+}


### PR DESCRIPTION
This pulls all of the resources for a spaceid, which can be a long list.  It's not currently paging, but if this gets slow, we could.  Currently I'm just returning the value in the Name tag, the ARN and the parsed values from the ARNs.