### PR TITLE
feat: support daily granularity for cost queries

### DIFF
--- a/api/handlers_spaces.go
+++ b/api/handlers_spaces.go
@@ -21,6 +21,7 @@ func (s *server) SpaceGetHandler(w http.ResponseWriter, r *http.Request) {
 	endTime := vars["end"]
 	spaceID := vars["space"]
 	groupBy := vars["groupby"]
+	granularity := vars["granularity"]
 
 	role := fmt.Sprintf("arn:aws:iam::%s:role/%s", account, s.session.RoleName)
 	policy, err := costExplorerReadPolicy()
@@ -37,11 +38,12 @@ func (s *server) SpaceGetHandler(w http.ResponseWriter, r *http.Request) {
 	out, cached, expire, err := orch.getCostAndUsageForSpace(
 		r.Context(),
 		&costAndUsageReq{
-			account: account,
-			spaceID: spaceID,
-			start:   startTime,
-			end:     endTime,
-			groupBy: groupBy,
+			account:     account,
+			spaceID:     spaceID,
+			start:       startTime,
+			end:         endTime,
+			groupBy:     groupBy,
+			granularity: granularity,
 		},
 	)
 	if err != nil {

--- a/api/orchestration_costexplorer.go
+++ b/api/orchestration_costexplorer.go
@@ -13,7 +13,7 @@ import (
 )
 
 type costAndUsageReq struct {
-	account, spaceID, start, end, groupBy string
+	account, spaceID, start, end, groupBy, granularity string
 }
 
 func (o *costExplorerOrchestrator) getCostAndUsageForSpace(ctx context.Context, req *costAndUsageReq) ([]*costexplorer.ResultByTime, bool, time.Duration, error) {
@@ -22,9 +22,14 @@ func (o *costExplorerOrchestrator) getCostAndUsageForSpace(ctx context.Context, 
 		return nil, false, 0, nil
 	}
 
+	granularity := "MONTHLY"
+	if req.granularity == "DAILY" {
+		granularity = "DAILY"
+	}
+
 	input := costexplorer.GetCostAndUsageInput{
 		Filter:      ce.And(inSpace(req.spaceID), inOrg(o.server.org), notTryIT()),
-		Granularity: aws.String("MONTHLY"),
+		Granularity: aws.String(granularity),
 		Metrics: []*string{
 			aws.String("BLENDED_COST"),
 			aws.String("UNBLENDED_COST"),
@@ -57,7 +62,7 @@ func (o *costExplorerOrchestrator) getCostAndUsageForSpace(ctx context.Context, 
 	// Since we will accept date-range cost exploring and grouping, concatenate
 	// the spaceID, the start time, end time and group by so we can cache each
 	// time-based result
-	cacheKey := fmt.Sprintf("%s_%s_%s_%s_%s", req.account, req.spaceID, req.start, req.end, req.groupBy)
+	cacheKey := fmt.Sprintf("%s_%s_%s_%s_%s_%s", req.account, req.spaceID, req.start, req.end, req.groupBy, granularity)
 
 	log.Debugf("cacheKey: %s", cacheKey)
 

--- a/api/routes.go
+++ b/api/routes.go
@@ -83,5 +83,9 @@ func matchSpaceQueries(req *http.Request, r *mux.RouteMatch) bool {
 		r.Vars["groupby"] = g[0]
 	}
 
+	if g, ok := queries["granularity"]; ok {
+		r.Vars["granularity"] = g[0]
+	}
+
 	return true
 }


### PR DESCRIPTION
The GetCostAndUsage call was hardcoded to MONTHLY granularity. Add an optional `granularity` query parameter (DAILY or MONTHLY, defaults to MONTHLY) so callers can request day-level cost data for trend charts. The parameter is included in the cache key to avoid serving monthly results for daily requests.